### PR TITLE
Add Support For Model-Specific Tokenizers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jdkato/prose/v2 v2.0.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/wbrown/gpt_bpe v0.0.0-20220209183333-91bb5abc3fed
+	github.com/wbrown/gpt_bpe v0.0.0-20220413190958-ee0155ca48f5
 	golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,9 +90,13 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wbrown/gpt_bpe v0.0.0-20220209183333-91bb5abc3fed h1:3f0pI/XwVOlCfx/7EpPbjNjOuyw2WvL8SUyNkHPfJEw=
 github.com/wbrown/gpt_bpe v0.0.0-20220209183333-91bb5abc3fed/go.mod h1:Sr5ApbUZJBONfqK5eeYd5AI7mpIr69medhLrG4NoB5o=
+github.com/wbrown/gpt_bpe v0.0.0-20220413190958-ee0155ca48f5 h1:6KcZKxG2V3myivX0wLGhM1BOqsvRoulCilY/+RVLQmE=
+github.com/wbrown/gpt_bpe v0.0.0-20220413190958-ee0155ca48f5/go.mod h1:2fIoTFduuUSZASx8LFUg9EOEUEZzKIQ68K6l3kEDdjM=
+github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/nrt.go
+++ b/nrt.go
@@ -388,6 +388,8 @@ func resolvePermutation(origPermutation ContentTest,
 		case "Model":
 			modelVal := value.String()
 			permutation.Parameters.Model = &modelVal
+			permutation.Scenario.Encoder = novelai_api.GetEncoderByModel(
+				modelVal)
 		default:
 			if value.Type() == stringType {
 				value.SetString(sanitizeString(value.String()))
@@ -575,7 +577,7 @@ func LoadSpecFromFile(path string) (test ContentTest) {
 			os.Exit(1)
 		}
 		fmt.Printf("ScenarioPath: %v\n", test.ScenarioPath)
-		if scenario, err := scenario.ScenarioFromFile(nil, test.ScenarioPath); err != nil {
+		if scenario, err := scenario.ScenarioFromFile(test.ScenarioPath); err != nil {
 			log.Printf("nrt: Error loading scenario: %v\n", err)
 			os.Exit(1)
 		} else {
@@ -610,8 +612,12 @@ func LoadSpecFromFile(path string) (test ContentTest) {
 		test.loadPrompt(test.PromptPath)
 	}
 	if test.ScenarioFilename == "" {
+		model := "euterpe-v2"
+		if test.Parameters.Model != nil {
+			model = *test.Parameters.Model
+		}
 		scenarioSpec := scenario.ScenarioFromSpec(test.Prompt, test.Memory,
-			test.AuthorsNote)
+			test.AuthorsNote, model)
 		test.Scenario = &scenarioSpec
 		test.Scenario.Settings.Parameters = &novelai_api.NaiGenerateParams{}
 		test.Scenario.Settings.Parameters.CoerceNullValues(&test.Parameters)
@@ -629,7 +635,7 @@ func MakeTestFromScenario(path string) (test ContentTest) {
 		os.Exit(1)
 	}
 	fmt.Printf("ScenarioPath: %v\n", test.ScenarioPath)
-	if sc, err := scenario.ScenarioFromFile(nil, test.ScenarioPath); err != nil {
+	if sc, err := scenario.ScenarioFromFile(test.ScenarioPath); err != nil {
 		log.Printf("nrt: Error loading scenario: %v\n", err)
 		os.Exit(1)
 	} else {

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -41,7 +41,7 @@ func (biasGroups *BiasGroups) RealizeBiases() {
 					Type:      BiasLitString,
 				}
 				phraseString := (*biasGroup.YamlPhrases)[phraseIdx]
-				tokens := gpt_bpe.Encoder.Encode(&phraseString)
+				tokens := gpt_bpe.GPT2Encoder.Encode(&phraseString)
 				jsonifiedPhrase.Sequences = append(jsonifiedPhrase.Sequences,
 					*tokens)
 				*(*biasGroups)[biasIdx].Phrases = append(

--- a/tests/a_laboratory_assistant.json
+++ b/tests/a_laboratory_assistant.json
@@ -5,8 +5,8 @@
   "iterations": 10,
   "generations": 10,
   "parameters": {
-    "model": "6B-v3",
-    "prefix": "theme_militaryscifi"
+    "model": "krake-v1",
+    "prefix": "theme_militaryscifi",
     "bad_word_ids": [[27,91,437,1659,5239,91,29],
       [1279,91,437,1659,5239,91,29],
       [27,91,10619,46,9792,13918,91,29],


### PR DESCRIPTION
Add support for multiple tokenizers based on model. As part of this work, refactor the scenario code and begin the process of breaking out context building from scenarios.

The `ContextBuilder` code can be used to build and manage contexts independently of `Scenario`s, but hasn't been pulled out of `scenario.go` yet.